### PR TITLE
Change the brand flex for mobile

### DIFF
--- a/docs/public/css/style.css
+++ b/docs/public/css/style.css
@@ -321,7 +321,7 @@ input.button {
 	.sidebar {
 		font-size: 0.8em;
 		flex: 0 0 auto;
-		flex-flow: row nowrap;
+		flex-flow: row wrap;
 		height: auto;
 	}
 
@@ -341,5 +341,9 @@ input.button {
 		flex: 0 0 0px;
 		visibility: hidden;
 		display: none;
+	}
+
+	.sidebar-brand {
+		width: 100%;
 	}
 }


### PR DESCRIPTION
- modified:   docs/public/css/style.css
  - In the sidebar, changed the `flex` property from `no-wrap` to `wrap` so for narrow screens, i.e. mobile, the navigation flex items will move to the second row.
  - This way everything isn't so squished in the sidebar.