### PR TITLE
Show bathtub_pkg source file lexical dependencies explicitly

### DIFF
--- a/examples/alu_division/qrun_test.sh
+++ b/examples/alu_division/qrun_test.sh
@@ -2,7 +2,7 @@
 
 
 qrun $BATHTUB_VIP_DIR/vip-spec.sv &&
-cp $BATHTUB_VIP_DIR/examples/alu_division/result/alu_division.feature .
+cp $BATHTUB_VIP_DIR/examples/alu_division/result/alu_division.feature . &&
 qrun \
 -uvm \
 -uvmhome $UVM_HOME \

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -21,10 +21,20 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+
+import uvm_pkg::*;
+
 typedef class gherkin_parser;
+`include "gherkin_parser.svh"
+
 typedef class gherkin_document_printer;
+`include "gherkin_document_printer.svh"
+
 typedef class gherkin_document_runner;
+`include "gherkin_document_runner.svh"
+
 typedef class gherkin_doc_bundle;
+`include "gherkin_doc_bundle.svh"
 
 class bathtub extends uvm_object;
 

--- a/src/bathtub_pkg/bathtub_macros.sv
+++ b/src/bathtub_pkg/bathtub_macros.sv
@@ -98,12 +98,12 @@ endfunction : set_current_scenario_sequence
 
 `define step_parameter_get_args_begin(f=get_step_attributes().get_expression())\
 begin : step_parameter_get_args\
-    step_parameters __step_params;\
+    bathtub_pkg::step_parameters __step_params;\
     int __next = 0;\
-	__step_params = step_parameters::create_new("__step_params", get_step_attributes().get_text(), f);
+	__step_params = bathtub_pkg::step_parameters::create_new("__step_params", get_step_attributes().get_text(), f);
 
 `else // BATHTUB__MULTILINE_MACRO_IS_OK
-`define step_parameter_get_args_begin(f=get_step_attributes().get_expression()) begin : step_parameter_get_args    step_parameters __step_params;    int __next = 0;	__step_params = step_parameters::create_new("__step_params", get_step_attributes().get_text(), f);
+`define step_parameter_get_args_begin(f=get_step_attributes().get_expression()) begin : step_parameter_get_args    bathtub_pkg::step_parameters __step_params;    int __next = 0;	__step_params = bathtub_pkg::step_parameters::create_new("__step_params", get_step_attributes().get_text(), f);
 `endif // BATHTUB__MULTILINE_MACRO_IS_OK
 
 `define step_parameter_get_arg_object(i) __step_params.get_arg(i)

--- a/src/bathtub_pkg/bathtub_pkg.sv
+++ b/src/bathtub_pkg/bathtub_pkg.sv
@@ -22,35 +22,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-//`include "uvm_macros.svh"
-//`include "bathtub_macros.sv"
+`include "bathtub_macros.sv"
 
 // ===================================================================
 package bathtub_pkg;
 // ===================================================================
 
-	`include "bathtub_pkg.svh"
-	
-	`include "bathtub_utils.svh"
-	`include "line_value.svh"
-	`include "pool_provider_interface.svh"
-	`include "pool_provider.svh"
-	`include "feature_sequence_interface.svh"
-	`include "feature_sequence.svh"
-	`include "scenario_sequence_interface.svh"
-	`include "scenario_sequence.svh"
-	`include "step_parameter_arg.svh"
-	`include "step_parameters.svh"
-	`include "step_static_attributes_interface.svh"
-	`include "step_nature.svh"
-	`include "step_attributes_interface.svh"
-	`include "step_nurture.svh"
-	`include "step_definition_interface.svh"
-	`include "gherkin_doc_bundle.svh"
+	// Main entry point
 	`include "bathtub.svh"
-	`include "gherkin_parser/gherkin_parser_interface.svh"
-	`include "gherkin_parser/gherkin_parser.svh"
-	`include "gherkin_document_printer/gherkin_document_printer.svh"
-	`include "gherkin_document_runner/gherkin_document_runner.svh"
+
+	// Resources for step definitions
+	`include "step_definition_interface.svh"
+	`include "step_static_attributes_interface.svh"
+	`include "step_attributes_interface.svh"
+	`include "step_nature.svh"
+	`include "step_parameters.svh"
+	`include "feature_sequence_interface.svh"
+	`include "scenario_sequence_interface.svh"
 
 endpackage : bathtub_pkg

--- a/src/bathtub_pkg/bathtub_pkg.sv
+++ b/src/bathtub_pkg/bathtub_pkg.sv
@@ -22,19 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-`include "uvm_macros.svh"
-`include "bathtub_macros.sv"
+//`include "uvm_macros.svh"
+//`include "bathtub_macros.sv"
 
 // ===================================================================
 package bathtub_pkg;
 // ===================================================================
 
-	import uvm_pkg::*;
-	
-	typedef enum {Given, When, Then, And, But, \* } step_keyword_t;
-	
-	parameter byte CR = 13; // ASCII carriage return
-	parameter string STEP_DEF_RESOURCE_NAME = "bathtub_pkg::step_definition_interface";
+	`include "bathtub_pkg.svh"
 	
 	`include "bathtub_utils.svh"
 	`include "line_value.svh"

--- a/src/bathtub_pkg/bathtub_pkg.svh
+++ b/src/bathtub_pkg/bathtub_pkg.svh
@@ -22,23 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-`ifndef __POOL_PROVIDER_INTERFACE_SVH
-`define __POOL_PROVIDER_INTERFACE_SVH
+`ifndef __BATHTUB_PKG_SVH
+`define __BATHTUB_PKG_SVH
 
-import uvm_pkg::*;
+typedef enum {Given, When, Then, And, But, \* } step_keyword_t;
 
-interface class pool_provider_interface;
-	pure virtual function uvm_pool#(string, shortint) get_shortint_pool();
-	pure virtual function uvm_pool#(string, int) get_int_pool();
-	pure virtual function uvm_pool#(string, longint) get_longint_pool();
-	pure virtual function uvm_pool#(string, byte) get_byte_pool();
-	pure virtual function uvm_pool#(string, integer) get_integer_pool();
-	pure virtual function uvm_pool#(string, time) get_time_pool();
-	pure virtual function uvm_pool#(string, real) get_real_pool();
-	pure virtual function uvm_pool#(string, shortreal) get_shortreal_pool();
-	pure virtual function uvm_pool#(string, realtime) get_realtime_pool();
-	pure virtual function uvm_pool#(string, string) get_string_pool();
-	pure virtual function uvm_pool#(string, uvm_object) get_uvm_object_pool();
-endclass : pool_provider_interface
+parameter byte CR = 13; // ASCII carriage return
+parameter string STEP_DEF_RESOURCE_NAME = "bathtub_pkg::step_definition_interface";
 
-`endif // __POOL_PROVIDER_INTERFACE_SVH
+`endif // __BATHTUB_PKG_SVH

--- a/src/bathtub_pkg/bathtub_utils.svh
+++ b/src/bathtub_pkg/bathtub_utils.svh
@@ -22,6 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __BATHTUB_UTILS_SVH
+`define __BATHTUB_UTILS_SVH
+
+`include "bathtub_pkg.svh"
+
+import uvm_pkg::*;
+
 virtual class bathtub_utils;
 // ===================================================================
 	static function bit split_string;
@@ -307,3 +314,5 @@ virtual class bathtub_utils;
 	endfunction : trim_white_space
 
 endclass : bathtub_utils
+
+`endif // __BATHTUB_UTILS_SVH

--- a/src/bathtub_pkg/feature_sequence.svh
+++ b/src/bathtub_pkg/feature_sequence.svh
@@ -22,10 +22,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __FEATURE_SEQUENCE_SVH
+`define __FEATURE_SEQUENCE_SVH
+
 `include "feature_sequence_interface.svh"
 
 typedef class pool_provider;
+`include "pool_provider.svh"
+
 typedef class gherkin_document_runner;
+`include "gherkin_document_runner.svh"
 
 class feature_sequence extends uvm_sequence implements feature_sequence_interface;
 	gherkin_pkg::feature feature;
@@ -97,3 +103,5 @@ class feature_sequence extends uvm_sequence implements feature_sequence_interfac
 	endfunction : get_uvm_object_pool
 
 endclass : feature_sequence
+
+`endif // __FEATURE_SEQUENCE_SVH

--- a/src/bathtub_pkg/gherkin_doc_bundle.svh
+++ b/src/bathtub_pkg/gherkin_doc_bundle.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __GHERKIN_DOC_BUNDLE_SVH
+`define __GHERKIN_DOC_BUNDLE_SVH
+
 // Bundle the document with its file name externally.
 // The AST doesn't provide a place for the file name inside the document.
 class gherkin_doc_bundle;
@@ -34,3 +37,5 @@ class gherkin_doc_bundle;
 	endfunction : new
 	
 endclass : gherkin_doc_bundle
+
+`endif // __GHERKIN_DOC_BUNDLE_SVH

--- a/src/bathtub_pkg/gherkin_document_printer/gherkin_document_printer.svh
+++ b/src/bathtub_pkg/gherkin_document_printer/gherkin_document_printer.svh
@@ -22,6 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __GHERKIN_DOCUMENT_PRINTER_SVH
+`define __GHERKIN_DOCUMENT_PRINTER_SVH
+
+import uvm_pkg::*;
+import gherkin_pkg::gherkin_document;
+
+`include "bathtub_pkg.svh"
+`include "uvm_macros.svh"
+
 class gherkin_document_printer extends uvm_object implements gherkin_pkg::visitor;
 
 	gherkin_pkg::gherkin_document document;
@@ -250,3 +259,5 @@ class gherkin_document_printer extends uvm_object implements gherkin_pkg::visito
 	endtask : visit_tag
 
 endclass : gherkin_document_printer
+
+`endif // __GHERKIN_DOCUMENT_PRINTER_SVH

--- a/src/bathtub_pkg/gherkin_document_runner/gherkin_document_runner.svh
+++ b/src/bathtub_pkg/gherkin_document_runner/gherkin_document_runner.svh
@@ -22,10 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __GHERKIN_DOCUMENT_RUNNER_SVH
+`define __GHERKIN_DOCUMENT_RUNNER_SVH
+
+`include "uvm_macros.svh"
+`include "bathtub_macros.sv"
+
+import gherkin_pkg::gherkin_document;
+import uvm_pkg::*;
+
 typedef class feature_sequence;
+`include "feature_sequence.svh"
+
 typedef class scenario_sequence;
+`include "scenario_sequence.svh"
+
 typedef class step_nurture;
-typedef class step_definition_interface;
+`include "step_nurture.svh"
+
+typedef interface class step_definition_interface;
+`include "step_definition_interface.svh"
 
 class gherkin_document_runner extends uvm_object implements gherkin_pkg::visitor;
 
@@ -78,7 +94,7 @@ class gherkin_document_runner extends uvm_object implements gherkin_pkg::visitor
 			uvm_sequence_base parent_sequence = null,
 			int sequence_priority = -1,
 			bit sequence_call_pre_post = 1,
-		uvm_phase starting_phase,
+			uvm_phase starting_phase,
 			bit dry_run = 0,
 			int starting_scenario_number = 0,
 			int stopping_scenario_number = 0
@@ -444,6 +460,6 @@ class gherkin_document_runner extends uvm_object implements gherkin_pkg::visitor
 
 	endtask : visit_tag
 
-
-
 endclass : gherkin_document_runner
+
+`endif // __GHERKIN_DOCUMENT_RUNNER_SVH

--- a/src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
+++ b/src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
@@ -22,6 +22,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __GHERKIN_PARSER_SVH
+`define __GHERKIN_PARSER_SVH
+
+`include "gherkin_parser_interface.svh"
+`include "bathtub_macros.sv"
+`include "uvm_macros.svh"
+
+typedef class line_value;
+`include "line_value.svh"
+
+typedef class bathtub_utils;
+`include "bathtub_utils.svh"
+
+import gherkin_pkg::gherkin_document;
+
+
 `define push_onto_parser_stack(o) parser_stack.push_front(o);
 
 `ifdef BATHTUB__MULTILINE_MACRO_IS_OK
@@ -37,11 +53,6 @@ end
 `else // BATHTUB__MULTILINE_MACRO_IS_OK
 `define pop_from_parser_stack(o) if (parser_stack.size() == 0) begin status = ERROR; `uvm_fatal(`get_scope_name(), "Visitor stack is empty") end else begin uvm_object obj = parser_stack.pop_front(); end
 `endif // BATHTUB__MULTILINE_MACRO_IS_OK
-
-`include "gherkin_parser_interface.svh"
-
-typedef class line_value;
-typedef class bathtub_utils;
 
 class gherkin_parser extends uvm_object implements gherkin_parser_interface;
 
@@ -367,3 +378,5 @@ endclass : gherkin_parser
 `include "parse_table_cell.svh"
 `include "parse_table_row.svh"
 `include "parse_tag.svh"
+
+`endif // __GHERKIN_PARSER_SVH

--- a/src/bathtub_pkg/gherkin_parser/gherkin_parser_interface.svh
+++ b/src/bathtub_pkg/gherkin_parser/gherkin_parser_interface.svh
@@ -26,6 +26,7 @@ SOFTWARE.
 `define __GHERKIN_PARSER_INTERFACE_SVH
 
 typedef class gherkin_doc_bundle;
+`include "gherkin_doc_bundle.svh"
 
 interface class gherkin_parser_interface;
 	pure virtual task parse_feature_file(input string feature_file_name, output gherkin_doc_bundle gherkin_doc_bndl);

--- a/src/bathtub_pkg/gherkin_parser/parse_background.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_background.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_BACKGROUND_SVH
+`define __PARSE_BACKGROUND_SVH
+
 task gherkin_parser::parse_background(ref gherkin_pkg::background background);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -140,3 +143,5 @@ task gherkin_parser::parse_background(ref gherkin_pkg::background background);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_background
+
+`endif // __PARSE_BACKGROUND_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_comment.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_comment.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_COMMENT_SVH
+`define __PARSE_COMMENT_SVH
+
 task gherkin_parser::parse_comment(ref gherkin_pkg::comment comment);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -66,3 +69,5 @@ task gherkin_parser::parse_comment(ref gherkin_pkg::comment comment);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_comment
+
+`endif // __PARSE_COMMENT_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_data_table.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_data_table.svh
@@ -22,6 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_DATA_TABLE_SVH
+`define __PARSE_DATA_TABLE_SVH
+
 task gherkin_parser::parse_data_table(ref gherkin_pkg::data_table data_table);
 	`uvm_fatal("PENDING", "")
 endtask : parse_data_table
+
+`endif // __PARSE_DATA_TABLE_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_doc_string.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_doc_string.svh
@@ -22,6 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_DOC_STRING_SVH
+`define __PARSE_DOC_STRING_SVH
+
 task gherkin_parser::parse_doc_string(ref gherkin_pkg::doc_string doc_string);
 	`uvm_fatal("PENDING", "")
 endtask : parse_doc_string
+
+`endif // __PARSE_DOC_STRING_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_examples.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_examples.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_EXAMPLES_SVH
+`define __PARSE_EXAMPLES_SVH
+
 task gherkin_parser::parse_examples(ref gherkin_pkg::examples examples);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -111,3 +114,5 @@ task gherkin_parser::parse_examples(ref gherkin_pkg::examples examples);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_examples
+
+`endif // __PARSE_EXAMPLES_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_feature.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_feature.svh
@@ -1,3 +1,30 @@
+/*
+MIT License
+
+Copyright (c) 2023 Everactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+`ifndef __PARSE_FEATURE_SVH
+`define __PARSE_FEATURE_SVH
+
 task gherkin_parser::parse_feature(ref gherkin_pkg::feature feature);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -109,3 +136,5 @@ task gherkin_parser::parse_feature(ref gherkin_pkg::feature feature);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_feature
+
+`endif // __PARSE_FEATURE_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_gherkin_document.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_gherkin_document.svh
@@ -1,3 +1,30 @@
+/*
+MIT License
+
+Copyright (c) 2023 Everactive
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+`ifndef __PARSE_GHERKIN_DOCUMENT_SVH
+`define __PARSE_GHERKIN_DOCUMENT_SVH
+
 task gherkin_parser::parse_gherkin_document(ref gherkin_pkg::gherkin_document gherkin_document);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -94,3 +121,5 @@ task gherkin_parser::parse_gherkin_document(ref gherkin_pkg::gherkin_document gh
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_gherkin_document
+
+`endif // __PARSE_GHERKIN_DOCUMENT_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_scenario.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_scenario.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_SCENARIO_SVH
+`define __PARSE_SCENARIO_SVH
+
 task gherkin_parser::parse_scenario(ref gherkin_pkg::scenario scenario);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -140,3 +143,5 @@ task gherkin_parser::parse_scenario(ref gherkin_pkg::scenario scenario);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_scenario
+
+`endif // __PARSE_SCENARIO_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_scenario_definition.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_scenario_definition.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_SCENARIO_DEFINITION_SVH
+`define __PARSE_SCENARIO_DEFINITION_SVH
+
 task gherkin_parser::parse_scenario_definition(ref gherkin_pkg::scenario_definition scenario_definition);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -62,3 +65,5 @@ task gherkin_parser::parse_scenario_definition(ref gherkin_pkg::scenario_definit
 	`uvm_message_add_object(scenario_definition)
 	`uvm_info_end
 endtask : parse_scenario_definition
+
+`endif // __PARSE_SCENARIO_DEFINITION_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_scenario_outline.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_scenario_outline.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_SCENARIO_OUTLINE_SVH
+`define __PARSE_SCENARIO_OUTLINE_SVH
+
 task gherkin_parser::parse_scenario_outline(ref gherkin_pkg::scenario_outline scenario_outline);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -158,3 +161,5 @@ task gherkin_parser::parse_scenario_outline(ref gherkin_pkg::scenario_outline sc
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_scenario_outline
+
+`endif // __PARSE_SCENARIO_OUTLINE_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_step.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_step.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_STEP_SVH
+`define __PARSE_STEP_SVH
+
 task gherkin_parser::parse_step(ref gherkin_pkg::step step);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -126,3 +129,5 @@ task gherkin_parser::parse_step(ref gherkin_pkg::step step);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_step
+
+`endif // __PARSE_STEP_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_step_argument.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_step_argument.svh
@@ -22,6 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_STEP_ARGUMENT_SVH
+`define __PARSE_STEP_ARGUMENT_SVH
+
 task gherkin_parser::parse_step_argument(ref gherkin_pkg::step_argument step_argument);
 	`uvm_fatal("PENDING", "")
 endtask : parse_step_argument
+
+`endif // __PARSE_STEP_ARGUMENT_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_table_cell.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_table_cell.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_TABLE_CELL_SVH
+`define __PARSE_TABLE_CELL_SVH
+
 task gherkin_parser::parse_table_cell(ref gherkin_pkg::table_cell table_cell);
 	string cell_value;
 	gherkin_pkg::table_cell_value table_cell_value;
@@ -43,3 +46,5 @@ task gherkin_parser::parse_table_cell(ref gherkin_pkg::table_cell table_cell);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_table_cell
+
+`endif // __PARSE_TABLE_CELL_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_table_row.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_table_row.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_TABLE_ROW_SVH
+`define __PARSE_TABLE_ROW_SVH
+
 task gherkin_parser::parse_table_row(ref gherkin_pkg::table_row table_row);
 	line_value line_obj;
 	line_analysis_result_t line_analysis_result;
@@ -85,3 +88,5 @@ task gherkin_parser::parse_table_row(ref gherkin_pkg::table_row table_row);
 	`uvm_info_end
 	`uvm_info(`get_scope_name(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_table_row
+
+`endif // __PARSE_TABLE_ROW_SVH

--- a/src/bathtub_pkg/gherkin_parser/parse_tag.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_tag.svh
@@ -22,6 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __PARSE_TAG_SVH
+`define __PARSE_TAG_SVH
+
 task gherkin_parser::parse_tag(ref gherkin_pkg::tag tag);
 	`uvm_fatal("PENDING", "")
 endtask : parse_tag
+
+`endif // __PARSE_TAG_SVH

--- a/src/bathtub_pkg/line_value.svh
+++ b/src/bathtub_pkg/line_value.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __LINE_VALUE_SVH
+`define __LINE_VALUE_SVH
+
 class line_value;
 	string text;
 	string file_name;
@@ -35,3 +38,5 @@ class line_value;
 		this.eof = eof;
 	endfunction : new
 endclass : line_value
+
+`endif // __LINE_VALUE_SVH

--- a/src/bathtub_pkg/pool_provider.svh
+++ b/src/bathtub_pkg/pool_provider.svh
@@ -22,6 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __POOL_PROVIDER_SVH
+`define __POOL_PROVIDER_SVH
+
 `include "pool_provider_interface.svh"
 
 class pool_provider implements pool_provider_interface;
@@ -107,3 +110,5 @@ class pool_provider implements pool_provider_interface;
 	endfunction : get_uvm_object_pool
 
 endclass : pool_provider
+
+`endif // __POOL_PROVIDER_SVH

--- a/src/bathtub_pkg/scenario_sequence.svh
+++ b/src/bathtub_pkg/scenario_sequence.svh
@@ -22,10 +22,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __SCENARIO_SEQUENCE_SVH
+`define __SCENARIO_SEQUENCE_SVH
+
 `include "scenario_sequence_interface.svh"
 
 typedef class gherkin_document_runner;
+`include "gherkin_document_runner.svh"
+
 typedef class pool_provider;
+`include "pool_provider.svh"
 
 class scenario_sequence extends uvm_sequence implements scenario_sequence_interface;
 	gherkin_pkg::scenario scenario;
@@ -116,3 +122,5 @@ class scenario_sequence extends uvm_sequence implements scenario_sequence_interf
 	endfunction : get_uvm_object_pool
 
 endclass : scenario_sequence
+
+`endif // __SCENARIO_SEQUENCE_SVH

--- a/src/bathtub_pkg/scenario_sequence_interface.svh
+++ b/src/bathtub_pkg/scenario_sequence_interface.svh
@@ -27,7 +27,8 @@ SOFTWARE.
 
 `include "pool_provider_interface.svh"
 
-typedef class feature_sequence_interface;
+typedef interface class feature_sequence_interface;
+`include "feature_sequence_interface.svh"
 
 interface class scenario_sequence_interface extends pool_provider_interface;
 	pure virtual function void set_current_feature_sequence(feature_sequence_interface seq);

--- a/src/bathtub_pkg/step_attributes_interface.svh
+++ b/src/bathtub_pkg/step_attributes_interface.svh
@@ -25,9 +25,14 @@ SOFTWARE.
 `ifndef __STEP_ATTRIBUTES_INTERFACE_SVH
 `define __STEP_ATTRIBUTES_INTERFACE_SVH
 
-typedef class feature_sequence_interface;
-typedef class scenario_sequence_interface;
-typedef class step_static_attributes_interface;
+typedef interface class feature_sequence_interface;
+`include "feature_sequence_interface.svh"
+
+typedef interface class scenario_sequence_interface;
+`include "scenario_sequence_interface.svh"
+
+typedef interface class step_static_attributes_interface;
+`include "step_static_attributes_interface.svh"
 
 interface class step_attributes_interface;
 	pure virtual function string get_runtime_keyword();

--- a/src/bathtub_pkg/step_definition_interface.svh
+++ b/src/bathtub_pkg/step_definition_interface.svh
@@ -25,7 +25,8 @@ SOFTWARE.
 `ifndef __STEP_DEFINITION_INTERFACE_SVH
 `define __STEP_DEFINITION_INTERFACE_SVH
 
-typedef class step_attributes_interface;
+typedef interface class step_attributes_interface;
+`include "step_attributes_interface.svh"
 
 interface class step_definition_interface;
 	pure virtual function step_attributes_interface get_step_attributes();

--- a/src/bathtub_pkg/step_nature.svh
+++ b/src/bathtub_pkg/step_nature.svh
@@ -23,8 +23,11 @@ SOFTWARE.
 */
 
 `include "step_static_attributes_interface.svh"
+`include "bathtub_macros.sv"
+`include "uvm_macros.svh"
 
 typedef class bathtub_utils;
+`include "bathtub_utils.svh"
 
 class step_nature extends uvm_object implements step_static_attributes_interface;
 

--- a/src/bathtub_pkg/step_nurture.svh
+++ b/src/bathtub_pkg/step_nurture.svh
@@ -22,7 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __STEP_NURTURE_SVH
+`define __STEP_NURTURE_SVH
+
 `include "step_attributes_interface.svh"
+`include "uvm_macros.svh"
 
 class step_nurture extends uvm_object implements step_attributes_interface;
 
@@ -127,3 +131,5 @@ class step_nurture extends uvm_object implements step_attributes_interface;
 	endfunction : set_current_scenario_sequence
 
 endclass : step_nurture
+
+`endif // __STEP_NURTURE_SVH

--- a/src/bathtub_pkg/step_parameter_arg.svh
+++ b/src/bathtub_pkg/step_parameter_arg.svh
@@ -22,6 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+`ifndef __STEP_PARAMETER_ARG_SVH
+`define __STEP_PARAMETER_ARG_SVH
+
+`include "uvm_macros.svh"
+import uvm_pkg::*;
+
 class step_parameter_arg extends uvm_object;
 	typedef enum {INVALID, INT, REAL, STRING} arg_type_t;
 	protected int int_arg;
@@ -98,3 +104,5 @@ class step_parameter_arg extends uvm_object;
 	endfunction : as_string
 	
 endclass : step_parameter_arg
+
+`endif // __STEP_PARAMETER_ARG_SVH

--- a/src/bathtub_pkg/step_parameters.svh
+++ b/src/bathtub_pkg/step_parameters.svh
@@ -22,8 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import uvm_pkg::*;
+
 typedef class bathtub_utils;
+`include "bathtub_utils.svh"
+
 typedef class step_parameter_arg;
+`include "step_parameter_arg.svh"
+
+`include "bathtub_macros.sv"
 
 class step_parameters extends uvm_object;
 	protected step_parameter_arg argv[$];

--- a/src/bathtub_pkg/step_static_attributes_interface.svh
+++ b/src/bathtub_pkg/step_static_attributes_interface.svh
@@ -25,6 +25,10 @@ SOFTWARE.
 `ifndef __STEP_STATIC_ATTRIBUTES_INTERFACE_SVH
 `define __STEP_STATIC_ATTRIBUTES_INTERFACE_SVH
 
+`include "bathtub_pkg.svh"
+
+import uvm_pkg::*;
+
 interface class step_static_attributes_interface;
 	
 	// Set keyword

--- a/src/bathtub_vip.F
+++ b/src/bathtub_vip.F
@@ -24,6 +24,8 @@ SOFTWARE.
 
 -incdir ./gherkin_pkg
 -incdir ./bathtub_pkg
+-incdir ./bathtub_pkg/gherkin_document_printer
+-incdir ./bathtub_pkg/gherkin_document_runner
 -incdir ./bathtub_pkg/gherkin_parser
 ./gherkin_pkg/gherkin_pkg.sv
 ./bathtub_pkg/bathtub_pkg.sv

--- a/src/bathtub_vip.f
+++ b/src/bathtub_vip.f
@@ -24,6 +24,8 @@ SOFTWARE.
 
 -incdir $BATHTUB_VIP_DIR/src/gherkin_pkg
 -incdir $BATHTUB_VIP_DIR/src/bathtub_pkg
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_printer
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_runner
 -incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_parser
 $BATHTUB_VIP_DIR/src/gherkin_pkg/gherkin_pkg.sv
 $BATHTUB_VIP_DIR/src/bathtub_pkg/bathtub_pkg.sv

--- a/test/bathtub_pkg_test_suite/pkg_test.py
+++ b/test/bathtub_pkg_test_suite/pkg_test.py
@@ -13,5 +13,3 @@ def test_qrun(tmp_path):
     svunit_cmd = "runSVUnit --sim qrun --uvm --out " + str(tmp_path)
     assert subprocess.run(svunit_cmd, shell=True).returncode == 0
 
-if __name__ == "__main__":
-    test()

--- a/test/dependency_test.py
+++ b/test/dependency_test.py
@@ -1,0 +1,59 @@
+import subprocess
+import pytest
+
+classes_under_test = [
+    "bathtub_pkg.svh",
+    "bathtub.svh",
+    "bathtub_utils.svh",
+    "feature_sequence_interface.svh",
+    "feature_sequence.svh",
+    "gherkin_doc_bundle.svh",
+    "line_value.svh",
+    "pool_provider_interface.svh",
+    "pool_provider.svh",
+    "scenario_sequence_interface.svh",
+    "scenario_sequence.svh",
+    "step_attributes_interface.svh",
+    "step_definition_interface.svh",
+    "step_nature.svh",
+    "step_nurture.svh",
+    "step_parameter_arg.svh",
+    "step_parameters.svh",
+    "step_static_attributes_interface.svh",
+    "gherkin_document_printer.svh",
+    "gherkin_document_runner.svh",
+    "gherkin_parser.svh",
+]
+
+@pytest.fixture(params=classes_under_test)
+def class_under_test(request):
+    return request.param
+
+@pytest.fixture(params=['xrun -uvmnocdnsextra', 'qrun'])
+def simulator(request):
+    return request.param
+
+def test_class_dependencies(tmp_path, simulator, class_under_test):
+    """Test that each class fully specifies all its dependencies"""
+    # Create a minimal top level that just includes the class file.
+    # Simulate it with only required packages and include directories.
+    # Class file should include everything it needs and compile successfully.
+    f = tmp_path / 'testbench.sv'
+    content = "\n".join(['program test();',
+                         '`include "' + class_under_test + '"',
+                        'endprogram : test'
+                        ])
+    f.write_text(content, encoding="utf-8")
+    run_cmd = simulator + " " + """\
+-uvm \
+-uvmhome $UVM_HOME \
+$BATHTUB_VIP_DIR/src/gherkin_pkg/gherkin_pkg.sv \
+-incdir $BATHTUB_VIP_DIR/src/gherkin_pkg \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_printer \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_runner \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_parser \
+testbench.sv \
+#
+"""
+    assert subprocess.run(run_cmd, shell=True, cwd=tmp_path).returncode == 0

--- a/test/dependency_test.py
+++ b/test/dependency_test.py
@@ -57,3 +57,54 @@ testbench.sv \
 #
 """
     assert subprocess.run(run_cmd, shell=True, cwd=tmp_path).returncode == 0
+
+def test_macro_dependencies(tmp_path, simulator):
+    """Test that bathtub_macros dependencies are satisfied by bathtub_pkg"""
+    # Bathtub_macros doesn't include or import any depencies on its own.
+    # Ensure that compiling bathtub_pkg satisfies bathtub_macros' requirements.
+    class_under_test = 'bathtub_macros.sv'
+    f = tmp_path / 'testbench.sv'
+    content = "\n".join(['program test();',
+                         '`include "' + class_under_test + '"',
+                        'endprogram : test'
+                        ])
+    f.write_text(content, encoding="utf-8")
+    run_cmd = simulator + " " + """\
+-uvm \
+-uvmhome $UVM_HOME \
+$BATHTUB_VIP_DIR/src/gherkin_pkg/gherkin_pkg.sv \
+$BATHTUB_VIP_DIR/src/bathtub_pkg/bathtub_pkg.sv \
+-incdir $BATHTUB_VIP_DIR/src/gherkin_pkg \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_printer \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_runner \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_parser \
+testbench.sv \
+#
+"""
+    assert subprocess.run(run_cmd, shell=True, cwd=tmp_path).returncode == 0
+
+def test_macro_command_line_dependencies(tmp_path, simulator):
+    """Test that bathtub_macros can be compiled from the command line"""
+    # The file is called "bathtub_macros.sv," not "bathtub_macros.svh," so ensure it can be compiled from the command line. 
+    f = tmp_path / 'testbench.sv'
+    content = "\n".join(['program test();',
+                         '; // Empty',
+                        'endprogram : test'
+                        ])
+    f.write_text(content, encoding="utf-8")
+    run_cmd = simulator + " " + """\
+-uvm \
+-uvmhome $UVM_HOME \
+$BATHTUB_VIP_DIR/src/gherkin_pkg/gherkin_pkg.sv \
+$BATHTUB_VIP_DIR/src/bathtub_pkg/bathtub_pkg.sv \
+$BATHTUB_VIP_DIR/src/bathtub_pkg/bathtub_macros.sv \
+-incdir $BATHTUB_VIP_DIR/src/gherkin_pkg \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_printer \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_document_runner \
+-incdir $BATHTUB_VIP_DIR/src/bathtub_pkg/gherkin_parser \
+testbench.sv \
+#
+"""
+    assert subprocess.run(run_cmd, shell=True, cwd=tmp_path).returncode == 0

--- a/vip-spec.sv
+++ b/vip-spec.sv
@@ -82,6 +82,8 @@ package bathtub_$vip_spec;
         incdirs: '{
             "src/gherkin_pkg",
             "src/bathtub_pkg",
+            "src/bathtub_pkg/gherkin_document_printer",
+            "src/bathtub_pkg/gherkin_document_runner",
             "src/bathtub_pkg/gherkin_parser"
         },
         files: '{


### PR DESCRIPTION
In many programming languages, managing code across multiple files requires some care and effort.
Whether they are called libraries, headers, modules, packages, etc., keeping track of files and dependencies is a challenge.
SystemVerilog has several ways to approach this:
- `include` compiler directives
- `-incdir` command line arguments
- Source files listed on the command line
- Packages
- `-v` and `-y` libraries

When I split `bathtub_pkg` into multiple files, I decided to try a radical approach to managing dependencies.
Rather than relying on the package file itself to include all required files, I let each class and task sub-file list its own dependencies.
This can be in the form of includes, class typedef forward declarations, and package imports.
This way each class file can stand on its own and be reused in different contexts if desired.
The class files are no longer dependent on the umbrella package to magically provide all its dependencies.
If the user wants to reuse a file, all its required dependencies are listed in the file, relatively clearly.