### PR TITLE
Implement parsing data tables

### DIFF
--- a/src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
+++ b/src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
@@ -325,7 +325,7 @@ class gherkin_parser extends uvm_object implements gherkin_parser_interface;
 
 	virtual task get_next_line(ref line_value line_obj);
 		line_mbox.get(line_obj);
-		$write("%s [%4d]: %s", line_obj.file_name, line_obj.line_number, line_obj.text);
+		// $write("%s [%4d]: %s", line_obj.file_name, line_obj.line_number, line_obj.text);
 
 		if (!line_obj.eof) begin
 
@@ -337,7 +337,7 @@ class gherkin_parser extends uvm_object implements gherkin_parser_interface;
 					if (bathtub_utils::trim_white_space(line_obj.text) == "") begin
 						// Discard empty lines
 						line_mbox.get(line_obj);
-						$write("%s [%4d]: %s", line_obj.file_name, line_obj.line_number, line_obj.text);
+						// $write("%s [%4d]: %s", line_obj.file_name, line_obj.line_number, line_obj.text);
 					end
 					else begin
 						break;

--- a/test/bathtub_pkg_test_suite/gherkin_parser_unit_test.sv
+++ b/test/bathtub_pkg_test_suite/gherkin_parser_unit_test.sv
@@ -140,6 +140,56 @@ module gherkin_parser_unit_test;
 	
   `SVTEST_END
 
+  `SVTEST(Parse_a_data_table)
+  // ========================
+  string feature[];
+  gherkin_doc_bundle actual_doc_bundle;
+  gherkin_pkg::feature actual_feature;
+  gherkin_pkg::scenario actual_scenario;
+  gherkin_pkg::step actual_step;
+  gherkin_pkg::data_table actual_data_table;
+
+  feature = {
+    "Feature: This is a feature",
+    "Scenario: This is a scenario",
+    "* This is a step",
+    "| Alpha | Bravo | Charlie |",
+    "| 100   | 200   | 300     |"
+  };
+
+  parser.parse_feature_lines(feature, actual_doc_bundle);
+  `FAIL_UNLESS(actual_doc_bundle)
+  
+  actual_feature = actual_doc_bundle.document.get_as_value().feature;
+  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
+  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
+  
+  `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
+  `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
+
+  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
+  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
+  `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
+  
+  actual_step = actual_scenario.get_as_value().base.steps[0];
+  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
+  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
+
+  `FAIL_UNLESS($cast(actual_data_table, actual_step.get_as_value().argument))
+  `FAIL_UNLESS_EQUAL(actual_data_table.get_as_value().rows.size(), 2)
+  for (int i = 0; i < actual_data_table.get_as_value().rows.size(); i++) begin
+    `FAIL_UNLESS_EQUAL(actual_data_table.get_as_value().rows[i].get_as_value().cells.size(), 3)
+  end
+
+  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[0].get_as_value().value, "Alpha")
+  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[1].get_as_value().value, "Bravo")
+  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[2].get_as_value().value, "Charlie")
+  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[0].get_as_value().value, "100")
+  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[1].get_as_value().value, "200")
+  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[2].get_as_value().value, "300")
+	
+  `SVTEST_END
+
 
   `SVUNIT_TESTS_END
 


### PR DESCRIPTION
Closes issue #43

- modified:   src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
  - Silence unconditional Gherkin echoing for now.
  - It was messing up the SVUnit logs.

- modified:   src/bathtub_pkg/gherkin_parser/parse_data_table.svh
  - Built out the `parse_data_table()` stub.

- modified:   test/bathtub_pkg_test_suite/gherkin_parser_unit_test.sv
  - New test `Parse_a_data_table`.