### PR TITLE
Implement parsing doc strings

### DIFF
--- a/src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
+++ b/src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
@@ -323,7 +323,7 @@ class gherkin_parser extends uvm_object implements gherkin_parser_interface;
 	endfunction : analyze_line
 
 
-	virtual task get_next_line(ref line_value line_obj);
+	virtual task get_next_line(ref line_value line_obj, input bit preserve_white_space=1'b0);
 		line_mbox.get(line_obj);
 		// $write("%s [%4d]: %s", line_obj.file_name, line_obj.line_number, line_obj.text);
 
@@ -334,7 +334,7 @@ class gherkin_parser extends uvm_object implements gherkin_parser_interface;
 
 				if (!line_obj.eof) begin
 
-					if (bathtub_utils::trim_white_space(line_obj.text) == "") begin
+					if (!preserve_white_space && bathtub_utils::trim_white_space(line_obj.text) == "") begin
 						// Discard empty lines
 						line_mbox.get(line_obj);
 						// $write("%s [%4d]: %s", line_obj.file_name, line_obj.line_number, line_obj.text);

--- a/src/bathtub_pkg/gherkin_parser/parse_data_table.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_data_table.svh
@@ -49,6 +49,8 @@ task gherkin_parser::parse_data_table(ref gherkin_pkg::data_table data_table);
 		case (line_analysis_result.secondary_keyword)
 			"|" : begin : configure_data_table
 
+				data_table_value.rows.delete();
+
 				while (status == OK) begin : rows
 					line_mbox.peek(line_obj);
 

--- a/src/bathtub_pkg/gherkin_parser/parse_doc_string.svh
+++ b/src/bathtub_pkg/gherkin_parser/parse_doc_string.svh
@@ -26,7 +26,83 @@ SOFTWARE.
 `define __PARSE_DOC_STRING_SVH
 
 task gherkin_parser::parse_doc_string(ref gherkin_pkg::doc_string doc_string);
-	`uvm_fatal("PENDING", "")
+	line_value line_obj;
+	line_analysis_result_t line_analysis_result;
+	gherkin_pkg::doc_string_value doc_string_value;
+	string delimiter = "";
+
+	line_mbox.peek(line_obj);
+
+	`uvm_info_begin(`BATHTUB__GET_SCOPE_NAME(), "gherkin_parser::parse_doc_string enter", UVM_HIGH)
+	`uvm_message_add_string(line_obj.file_name)
+	`uvm_message_add_int(line_obj.line_number, UVM_DEC)
+	`uvm_message_add_int(line_obj.eof, UVM_BIN)
+	if (!line_obj.eof) begin
+		`uvm_message_add_string(line_obj.text)
+	end
+	`uvm_info_end
+	`uvm_info(`BATHTUB__GET_SCOPE_NAME(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
+
+	if (!line_obj.eof) begin
+
+		analyze_line(line_obj.text, line_analysis_result);
+
+		case (line_analysis_result.secondary_keyword)
+			"\"\"\"", "```" : begin : configure_doc_string
+				delimiter = line_analysis_result.secondary_keyword;
+
+				doc_string_value.content_type = line_analysis_result.remainder_after_secondary_keyword;
+				doc_string_value.content = "";
+
+				get_next_line(line_obj);
+
+				while (status == OK) begin : content
+					line_mbox.peek(line_obj);
+
+					if (line_obj.eof) break;
+
+					analyze_line(line_obj.text, line_analysis_result);
+
+					case (line_analysis_result.secondary_keyword)
+						delimiter : begin : terminate
+							// Matching delimiter terminates the doc string
+
+							if (line_analysis_result.remainder_after_secondary_keyword.len() != 0) begin
+								status = ERROR;
+								`uvm_error(`BATHTUB__GET_SCOPE_NAME(), {"Unexpected content type after closing delimiter: ", line_analysis_result.remainder_after_secondary_keyword,
+									". Expecting nothing."})
+							end
+
+							get_next_line(line_obj);
+							break;
+						end
+
+						default : begin : construct_content
+							// Newline gets trimmed by parser, so append a new one.
+							doc_string_value.content = {doc_string_value.content, line_obj.text, "\n"};
+							// Preserve all white space in a doc string
+							get_next_line(.line_obj(line_obj), .preserve_white_space(1'b1));
+						end
+					endcase
+				end
+			end
+
+			default : begin
+				status = ERROR;
+				`uvm_error(`BATHTUB__GET_SCOPE_NAME(), {"Unexpected keyword: ", line_analysis_result.secondary_keyword,
+					". Expecting \"\"\" or ```"})
+			end
+		endcase
+	end
+
+	doc_string = new("data_table", doc_string_value);
+	`push_onto_parser_stack(doc_string)
+
+	`uvm_info_begin(`BATHTUB__GET_SCOPE_NAME(), "gherkin_parser::parse_doc_string exit", UVM_HIGH)
+	`uvm_message_add_tag("status", status.name())
+	`uvm_message_add_object(doc_string)
+	`uvm_info_end
+	`uvm_info(`BATHTUB__GET_SCOPE_NAME(), $sformatf("parser_stack: %p", parser_stack), UVM_HIGH)
 endtask : parse_doc_string
 
 `endif // __PARSE_DOC_STRING_SVH

--- a/test/bathtub_pkg_test_suite/gherkin_parser_unit_test.sv
+++ b/test/bathtub_pkg_test_suite/gherkin_parser_unit_test.sv
@@ -63,131 +63,211 @@ module gherkin_parser_unit_test;
   `SVUNIT_TESTS_BEGIN
 
   `SVTEST(Task_parse_feature_lines_should_parse_a_minimal_feature_array)
-  // ===================================================================
-  string feature[];
-  gherkin_doc_bundle actual_doc_bundle;
-	string actual_file_name, expected_file_name;
-  gherkin_pkg::feature actual_feature;
-  gherkin_pkg::scenario actual_scenario;
-  gherkin_pkg::step actual_step;
+    // ===================================================================
+    string feature[];
+    gherkin_doc_bundle actual_doc_bundle;
+    string actual_file_name, expected_file_name;
+    gherkin_pkg::feature actual_feature;
+    gherkin_pkg::scenario actual_scenario;
+    gherkin_pkg::step actual_step;
 
-  feature = {
-    "Feature: This is a feature",
-    "Scenario: This is a scenario",
-    "* This is a step"
-  };
+    feature = {
+      "Feature: This is a feature",
+      "Scenario: This is a scenario",
+      "* This is a step"
+    };
 
-  parser.parse_feature_lines(feature, actual_doc_bundle);
-  `FAIL_UNLESS(actual_doc_bundle)
+    parser.parse_feature_lines(feature, actual_doc_bundle);
+    `FAIL_UNLESS(actual_doc_bundle)
 
-  actual_file_name = actual_doc_bundle.file_name;
-  expected_file_name = "";
-  `FAIL_UNLESS_STR_EQUAL(actual_file_name, expected_file_name)
-  
-  actual_feature = actual_doc_bundle.document.get_as_value().feature;
-  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
-  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
-  
-  `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
-  `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
+    actual_file_name = actual_doc_bundle.file_name;
+    expected_file_name = "";
+    `FAIL_UNLESS_STR_EQUAL(actual_file_name, expected_file_name)
+    
+    actual_feature = actual_doc_bundle.document.get_as_value().feature;
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
+    
+    `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
+    `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
 
-  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
-  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
-  `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
-  
-  actual_step = actual_scenario.get_as_value().base.steps[0];
-  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
-  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
+    `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
+    
+    actual_step = actual_scenario.get_as_value().base.steps[0];
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
 	
   `SVTEST_END
 
   `SVTEST(Task_parse_feature_string_should_parse_a_minimal_feature_string)
-  // =====================================================================
-  string feature;
-  gherkin_doc_bundle actual_doc_bundle;
-	string actual_file_name, expected_file_name;
-  gherkin_pkg::feature actual_feature;
-  gherkin_pkg::scenario actual_scenario;
-  gherkin_pkg::step actual_step;
+    // =====================================================================
+    string feature;
+    gherkin_doc_bundle actual_doc_bundle;
+    string actual_file_name, expected_file_name;
+    gherkin_pkg::feature actual_feature;
+    gherkin_pkg::scenario actual_scenario;
+    gherkin_pkg::step actual_step;
 
-  feature = {
-    "Feature: This is a feature\n",
-    "Scenario: This is a scenario\n",
-    "* This is a step"
-  };
+    feature = {
+      "Feature: This is a feature\n",
+      "Scenario: This is a scenario\n",
+      "* This is a step"
+    };
 
-  parser.parse_feature_string(feature, actual_doc_bundle);
-  `FAIL_UNLESS(actual_doc_bundle)
+    parser.parse_feature_string(feature, actual_doc_bundle);
+    `FAIL_UNLESS(actual_doc_bundle)
 
-  actual_file_name = actual_doc_bundle.file_name;
-  expected_file_name = "";
-  `FAIL_UNLESS_STR_EQUAL(actual_file_name, expected_file_name)
-  
-  actual_feature = actual_doc_bundle.document.get_as_value().feature;
-  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
-  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
-  
-  `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
-  `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
+    actual_file_name = actual_doc_bundle.file_name;
+    expected_file_name = "";
+    `FAIL_UNLESS_STR_EQUAL(actual_file_name, expected_file_name)
+    
+    actual_feature = actual_doc_bundle.document.get_as_value().feature;
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
+    
+    `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
+    `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
 
-  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
-  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
-  `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
-  
-  actual_step = actual_scenario.get_as_value().base.steps[0];
-  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
-  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
+    `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
+    
+    actual_step = actual_scenario.get_as_value().base.steps[0];
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
 	
   `SVTEST_END
 
   `SVTEST(Parse_a_data_table)
-  // ========================
-  string feature[];
-  gherkin_doc_bundle actual_doc_bundle;
-  gherkin_pkg::feature actual_feature;
-  gherkin_pkg::scenario actual_scenario;
-  gherkin_pkg::step actual_step;
-  gherkin_pkg::data_table actual_data_table;
+    // ========================
+    string feature[];
+    gherkin_doc_bundle actual_doc_bundle;
+    gherkin_pkg::feature actual_feature;
+    gherkin_pkg::scenario actual_scenario;
+    gherkin_pkg::step actual_step;
+    gherkin_pkg::data_table actual_data_table;
 
-  feature = {
-    "Feature: This is a feature",
-    "Scenario: This is a scenario",
-    "* This is a step",
-    "| Alpha | Bravo | Charlie |",
-    "| 100   | 200   | 300     |"
-  };
+    feature = {
+      "Feature: This is a feature",
+      "Scenario: This is a scenario",
+      "* This is a step",
+      "| Alpha | Bravo | Charlie |",
+      "| 100   | 200   | 300     |"
+    };
 
-  parser.parse_feature_lines(feature, actual_doc_bundle);
-  `FAIL_UNLESS(actual_doc_bundle)
-  
-  actual_feature = actual_doc_bundle.document.get_as_value().feature;
-  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
-  `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
-  
-  `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
-  `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
+    parser.parse_feature_lines(feature, actual_doc_bundle);
+    `FAIL_UNLESS(actual_doc_bundle)
+    
+    actual_feature = actual_doc_bundle.document.get_as_value().feature;
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
+    
+    `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
+    `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
 
-  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
-  `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
-  `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
-  
-  actual_step = actual_scenario.get_as_value().base.steps[0];
-  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
-  `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
+    `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
+    
+    actual_step = actual_scenario.get_as_value().base.steps[0];
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
 
-  `FAIL_UNLESS($cast(actual_data_table, actual_step.get_as_value().argument))
-  `FAIL_UNLESS_EQUAL(actual_data_table.get_as_value().rows.size(), 2)
-  for (int i = 0; i < actual_data_table.get_as_value().rows.size(); i++) begin
-    `FAIL_UNLESS_EQUAL(actual_data_table.get_as_value().rows[i].get_as_value().cells.size(), 3)
-  end
+    `FAIL_UNLESS($cast(actual_data_table, actual_step.get_as_value().argument))
+    `FAIL_UNLESS_EQUAL(actual_data_table.get_as_value().rows.size(), 2)
+    for (int i = 0; i < actual_data_table.get_as_value().rows.size(); i++) begin
+      `FAIL_UNLESS_EQUAL(actual_data_table.get_as_value().rows[i].get_as_value().cells.size(), 3)
+    end
 
-  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[0].get_as_value().value, "Alpha")
-  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[1].get_as_value().value, "Bravo")
-  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[2].get_as_value().value, "Charlie")
-  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[0].get_as_value().value, "100")
-  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[1].get_as_value().value, "200")
-  `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[2].get_as_value().value, "300")
+    `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[0].get_as_value().value, "Alpha")
+    `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[1].get_as_value().value, "Bravo")
+    `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[0].get_as_value().cells[2].get_as_value().value, "Charlie")
+    `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[0].get_as_value().value, "100")
+    `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[1].get_as_value().value, "200")
+    `FAIL_UNLESS_STR_EQUAL(actual_data_table.get_as_value().rows[1].get_as_value().cells[2].get_as_value().value, "300")
 	
+  `SVTEST_END
+
+  `SVTEST(Parse_a_doc_string)
+    // ========================
+    string feature;
+    gherkin_doc_bundle actual_doc_bundle;
+    gherkin_pkg::feature actual_feature;
+    gherkin_pkg::scenario actual_scenario;
+    gherkin_pkg::step actual_step;
+    gherkin_pkg::doc_string actual_doc_string;
+    localparam string triple_quotes = "\"\"\"\n";
+
+    feature = {
+      "Feature: This is a feature\n",
+      "Scenario: This is a scenario\n",
+      "* This is a step\n",
+      triple_quotes,
+      "Alpha\n",
+      "Bravo\n",
+      "Charlie\n",
+      triple_quotes
+    };
+
+    parser.parse_feature_string(feature, actual_doc_bundle);
+    `FAIL_UNLESS(actual_doc_bundle)
+    
+    actual_feature = actual_doc_bundle.document.get_as_value().feature;
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().keyword, "Feature")
+    `FAIL_UNLESS_STR_EQUAL(actual_feature.get_as_value().feature_name, "This is a feature")
+    
+    `FAIL_UNLESS_EQUAL(actual_feature.get_as_value().scenario_definitions.size(), 1)
+    `FAIL_UNLESS($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]))
+
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.keyword, "Scenario")
+    `FAIL_UNLESS_STR_EQUAL(actual_scenario.get_as_value().base.scenario_definition_name, "This is a scenario")
+    `FAIL_UNLESS_EQUAL(actual_scenario.get_as_value().base.steps.size(), 1)
+    
+    actual_step = actual_scenario.get_as_value().base.steps[0];
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().keyword, "*")
+    `FAIL_UNLESS_STR_EQUAL(actual_step.get_as_value().text, "This is a step")
+
+    `FAIL_UNLESS($cast(actual_doc_string, actual_step.get_as_value().argument))
+    `FAIL_UNLESS(actual_doc_string.get_as_value().content.len() > 0)
+    `FAIL_UNLESS_STR_EQUAL(actual_doc_string.get_as_value().content_type, "")
+    `FAIL_UNLESS_STR_EQUAL(actual_doc_string.get_as_value().content, "Alpha\nBravo\nCharlie\n")
+  `SVTEST_END
+
+  `SVTEST(Parse_a_doc_string_that_contains_white_space)
+    // ========================
+    string feature;
+    gherkin_doc_bundle actual_doc_bundle;
+    gherkin_pkg::feature actual_feature;
+    gherkin_pkg::scenario actual_scenario;
+    gherkin_pkg::step actual_step;
+    gherkin_pkg::doc_string actual_doc_string;
+    localparam string triple_quotes = "\"\"\"\n";
+
+    feature = {
+      "Feature: This is a feature\n",
+      "Scenario: This is a scenario\n",
+      "* This is a step\n",
+      triple_quotes,
+      "Alpha   \n",
+      "   Bravo\n",
+      "   \n",
+      "\n",
+      "Charlie\n",
+      triple_quotes
+    };
+
+    parser.parse_feature_string(feature, actual_doc_bundle);
+    `FAIL_UNLESS(actual_doc_bundle)
+    
+    actual_feature = actual_doc_bundle.document.get_as_value().feature;
+    void'($cast(actual_scenario, actual_feature.get_as_value().scenario_definitions[0]));
+    actual_step = actual_scenario.get_as_value().base.steps[0];
+    void'($cast(actual_doc_string, actual_step.get_as_value().argument));
+    `FAIL_UNLESS(actual_doc_string.get_as_value().content.len() > 0)
+    `FAIL_UNLESS_STR_EQUAL(actual_doc_string.get_as_value().content_type, "")
+    `FAIL_UNLESS_STR_EQUAL(actual_doc_string.get_as_value().content, "Alpha   \n   Bravo\n   \n\nCharlie\n")
   `SVTEST_END
 
 


### PR DESCRIPTION
Closes issue #45.

- modified:   src/bathtub_pkg/gherkin_parser/parse_doc_string.svh
  - Built out `parse_doc_string()` placeholder stub.

- modified:   test/bathtub_pkg_test_suite/gherkin_parser_unit_test.sv
  - New test `Parse_a_doc_string`
  - New test `Parse_a_doc_string_that_contains_white_space`

- modified:   src/bathtub_pkg/gherkin_parser/gherkin_parser.svh
  - Added `preserve_white_space` option to `get_new_line()` because doc strings should preserve all leading and trailing white space and empty lines.

- modified:   src/bathtub_pkg/gherkin_parser/parse_data_table.svh
  - Explicitly delete the `data_table_value` rows, just to make the intent clear.