### PR TITLE
Add p_sequencer to snippet

### DIFF
--- a/src/bathtub_pkg/snippets.svh
+++ b/src/bathtub_pkg/snippets.svh
@@ -49,6 +49,8 @@ virtual class snippets extends uvm_object;
         create_snippet = {create_snippet, "class ", class_name, " extends uvm_pkg::uvm_sequence implements bathtub_pkg::step_definition_interface;", "\n"};
         create_snippet = {create_snippet, "    ", keyword_macro, "(\"", step.get_text(), "\")", "\n"};
         create_snippet = {create_snippet, "    `uvm_object_utils(", class_name, ")", "\n"};
+        create_snippet = {create_snippet, "    // Declare the correct virtual sequencer type here", "\n"};
+        create_snippet = {create_snippet, "    `uvm_declare_p_sequencer(uvm_sequencer)", "\n"};
         create_snippet = {create_snippet, "    function new (string name=\"", class_name, "\");", "\n"};
         create_snippet = {create_snippet, "        super.new(name);", "\n"};
         create_snippet = {create_snippet, "    endfunction : new", "\n"};


### PR DESCRIPTION
Closes Issue #92 

- modified:   src/bathtub_pkg/snippets.svh
  - Declare `p_sequence` with a type placeholder.
  - User should replace the placeholder with the type of the virtual sequencer they pass to Bathtub.
  - This allows the step definition to reference resources in the virtual sequencer.

- modified:   test/e2e/basic/basic_test.py
  - Refactor the snippet test by breaking it into two tests.
  - Reuse the first snippet test in new test `test_basic_working_snippet_e2e`.