### PR TITLE
Create wiki reference page for bathtub class

### DIFF
--- a/examples/alu_division/result/testbench.sv
+++ b/examples/alu_division/result/testbench.sv
@@ -109,7 +109,7 @@ module top();
     
     task run_phase(uvm_phase phase);
       bathtub.configure(my_alu_env.alu_vseqr); // Virtual sequencer
-      bathtub.feature_files.push_back("alu_division.feature"); // Feature file
+      bathtub.push_back_feature_file("alu_division.feature"); // Feature file
       phase.raise_objection(this);
       bathtub.run_test(phase); // Run Bathtub!
       phase.drop_objection(this);

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -237,71 +237,144 @@ The snippets can be used as the basis for actual step definitions.\
 	endfunction : write_snippets
 
 
+	(* doc$markdown = "\
+Gets the plusarg options object.\
+\
+The plus arg options object contains values passed as `+bathtub_*` plusargs on the simulator command line.\
+	"*)
 	function plusarg_options get_plusarg_opts();
 		return plusarg_opts;
 	endfunction : get_plusarg_opts
 
-
+	(* doc$markdown = "\
+Gets the list of feature files.\
+\
+`strings_t` is a typedef for `uvm_queue#(string)`.\
+	"*)
 	function strings_t get_feature_files();
 		get_feature_files = new("feature_files");
 		foreach (feature_files[i]) get_feature_files.push_back(feature_files[i]);
 	endfunction : get_feature_files
 
+	(* doc$markdown = "\
+Concatenates strings to the end of the internal list of feature files to run.\
+\
+`files` is a queue of strings.\
+Each string should be a single filename or a whitespace-separated list of filenames for Gherkin feature files.\
+\
+e.g.\
+```\
+bathtub.concat_feature_files('{\"path/to/features/feature_A.feature\"});\
+bathtub.concat_feature_files('{\"path/to/features/feature_B.feature\", \"path/to/features/feature_C.feature\"});\
+bathtub.concat_feature_files('{\"path/to/features/feature_D.feature path/to/features/feature_E.feature\"});\
+bathtub.concat_feature_files(my_queue_of_strings);\
+bathtub.run_test(phase);\
+```\
+	"*)
 	function void concat_feature_files(string files[$]);
 		feature_files = {feature_files, files};
 	endfunction : concat_feature_files
 
+	(* doc$markdown = "\
+Pushes a single string to the end of the internal list of feature files to run.\
+\
+`file` should be a single filename or a whitespace-separated list of filenames for Gherkin feature files.\
+e.g.\
+```\
+bathtub.push_back_feature_file(\"path/to/features/feature_A.feature\");\
+bathtub.push_back_feature_file(\"path/to/features/feature_B.feature path/to/features/feature_C.feature\");\
+bathtub.run_test(phase);\
+	"*)
 	function void push_back_feature_file(string file);
 		feature_files.push_back(file);
 	endfunction : push_back_feature_file
 
+	(* doc$markdown = "\
+Sets the Bathtub object's report object.\
+\
+By default, Bathtub is its own UVM report object for the reports (`` `uvm_info()``, `` `uvm_error()``, etc.) it issues.\
+This accessor assigns a different report object.\
+e.g.\
+```\
+bathtub.set_report_object(uvm_root::get()); // Global object\
+bathtub.set_report_object(bathtub); // Back to self\
+```\
+	"*)
 	function void set_report_object(uvm_report_object report_object);
 		this.report_object = report_object;
 	endfunction : set_report_object
 	
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function uvm_report_object get_report_object();
 		return report_object;
 	endfunction : get_report_object
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function uvm_sequencer_base get_sequencer();
 		return sequencer;
 	endfunction : get_sequencer
 	
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function int get_sequence_priority();
 		return sequence_priority;
 	endfunction : get_sequence_priority
 	
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function bit get_sequence_call_pre_post();
 		return sequence_call_pre_post;
 	endfunction : get_sequence_call_pre_post
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function bit get_dry_run();
 		return dry_run;
 	endfunction : get_dry_run
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function int get_starting_scenario_number();
 		return starting_scenario_number;
 	endfunction : get_starting_scenario_number
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function int get_stopping_scenario_number();
 		return stopping_scenario_number;
 	endfunction : get_stopping_scenario_number
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function strings_t get_include_tags();
 		get_include_tags = new("include_tags");
 		foreach (include_tags[i]) get_include_tags.push_back(include_tags[i]);
 	endfunction : get_include_tags
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function strings_t get_exclude_tags();
 		get_exclude_tags = new("exclude_tags");
 		foreach (exclude_tags[i]) get_exclude_tags.push_back(exclude_tags[i]);
 	endfunction : get_exclude_tags
 
+	(* doc$markdown = "\
+docstring\
+	"*)
 	function void concat_undefined_steps(gherkin_pkg::step steps[$]);
 		undefined_steps = {undefined_steps, steps};
 	endfunction : concat_undefined_steps
-
-
 
 endclass : bathtub
 

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -284,6 +284,7 @@ e.g.\
 bathtub.push_back_feature_file(\"path/to/features/feature_A.feature\");\
 bathtub.push_back_feature_file(\"path/to/features/feature_B.feature path/to/features/feature_C.feature\");\
 bathtub.run_test(phase);\
+```\
 	"*)
 	function void push_back_feature_file(string file);
 		feature_files.push_back(file);

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -58,24 +58,24 @@ typedef class snippets;
 
 class bathtub extends uvm_report_object;
 
-	string feature_files[$];
+	protected string feature_files[$];
 
-	gherkin_doc_bundle gherkin_docs[$];
-	uvm_sequencer_base sequencer;
-	uvm_sequence_base parent_sequence;
-	int sequence_priority;
-	bit sequence_call_pre_post;
-	bit dry_run;
-	int starting_scenario_number;
-	int stopping_scenario_number;
-	uvm_verbosity bathtub_verbosity;
-	uvm_report_object report_object;
-	string include_tags[$];
-	string exclude_tags[$];
-	test_sequence current_test_seq;
-	gherkin_pkg::step undefined_steps[$];
+	protected gherkin_doc_bundle gherkin_docs[$];
+	protected uvm_sequencer_base sequencer;
+	protected uvm_sequence_base parent_sequence;
+	protected int sequence_priority;
+	protected bit sequence_call_pre_post;
+	protected bit dry_run;
+	protected int starting_scenario_number;
+	protected int stopping_scenario_number;
+	protected uvm_verbosity bathtub_verbosity;
+	protected uvm_report_object report_object;
+	protected string include_tags[$];
+	protected string exclude_tags[$];
+	protected test_sequence current_test_seq;
+	protected gherkin_pkg::step undefined_steps[$];
 	
-	static plusarg_options plusarg_opts = plusarg_options::create().populate();
+	protected static plusarg_options plusarg_opts = plusarg_options::create().populate();
 
 	`uvm_object_utils_begin(bathtub)
 		`uvm_field_queue_string(feature_files, UVM_ALL_ON)
@@ -155,7 +155,7 @@ class bathtub extends uvm_report_object;
 	endtask : run_test
 
 
-	virtual function void write_snippets();
+	protected virtual function void write_snippets();
         string file_name;
         bit[31:0] fd;
 
@@ -195,6 +195,57 @@ class bathtub extends uvm_report_object;
 	function plusarg_options get_plusarg_opts();
 		return plusarg_opts;
 	endfunction : get_plusarg_opts
+
+
+	function strings_t get_feature_files();
+		get_feature_files = new("feature_files");
+		foreach (feature_files[i]) get_feature_files.push_back(feature_files[i]);
+	endfunction : get_feature_files
+
+	
+	function uvm_report_object get_report_object();
+		return report_object;
+	endfunction : get_report_object
+
+	function uvm_sequencer_base get_sequencer();
+		return sequencer;
+	endfunction : get_sequencer
+	
+	function int get_sequence_priority();
+		return sequence_priority;
+	endfunction : get_sequence_priority
+	
+	function bit get_sequence_call_pre_post();
+		return sequence_call_pre_post;
+	endfunction : get_sequence_call_pre_post
+
+	function bit get_dry_run();
+		return dry_run;
+	endfunction : get_dry_run
+
+	function int get_starting_scenario_number();
+		return starting_scenario_number;
+	endfunction : get_starting_scenario_number
+
+	function int get_stopping_scenario_number();
+		return stopping_scenario_number;
+	endfunction : get_stopping_scenario_number
+
+	function strings_t get_include_tags();
+		get_include_tags = new("include_tags");
+		foreach (include_tags[i]) get_include_tags.push_back(include_tags[i]);
+	endfunction : get_include_tags
+
+	function strings_t get_exclude_tags();
+		get_exclude_tags = new("exclude_tags");
+		foreach (exclude_tags[i]) get_exclude_tags.push_back(exclude_tags[i]);
+	endfunction : get_exclude_tags
+
+	function void concat_undefined_steps(gherkin_pkg::step steps[$]);
+		undefined_steps = {undefined_steps, steps};
+	endfunction : concat_undefined_steps
+
+
 
 endclass : bathtub
 

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -84,6 +84,12 @@ class bathtub extends uvm_report_object;
 		`uvm_field_int(stopping_scenario_number, UVM_ALL_ON)
 	`uvm_object_utils_end
 
+
+	(* doc$markdown = "\
+Constructor.\
+\
+Initializes the Bathtub object with the given `name`.\
+	"*)
 	function new(string name = "bathtub");
 		super.new(name);
 
@@ -103,19 +109,31 @@ class bathtub extends uvm_report_object;
 		undefined_steps.delete();
 	endfunction : new
 
-
+	(* doc$markdown = "\
+Configures the Bathtub object prior to running it.\
+\
+Parameters `sequencer`, `parent_sequence`, `sequence_priority`, and `sequence_call_pre_post` are all related to the respective arguments of `uvm_sequence_base::start()`.\
+These parameters all influence how Bathtub executes its sequences.\
+\
+`sequencer` is the sequencer on which Bathtub will execute all its context and step definition sequences.\
+\
+The Bathtub object creates its own context sequence called `current_test_seq`.\
+If `parent_sequence` is null, then `current_test_seq` is a root parent, otherwise it is a child of `parent_sequence`.\
+\
+Bathtub assigns `sequence_priority` to all its context and step definition sequences.\
+\
+`sequence_call_pre_post` determines whether the sequences' `pre_body()` and `post_body()` tasks are called.\
+	"*)
 	virtual function void configure(
 			uvm_sequencer_base sequencer,
 			uvm_sequence_base parent_sequence = null,
 			int sequence_priority = 100,
-			bit sequence_call_pre_post = 1,
-			uvm_report_object report_object = null
+			bit sequence_call_pre_post = 1
 		);
 		this.sequencer = sequencer;
 		this.parent_sequence = parent_sequence;
 		this.sequence_priority = sequence_priority;
 		this.sequence_call_pre_post = sequence_call_pre_post;
-		this.report_object = report_object;
 	endfunction : configure
 
 
@@ -209,6 +227,10 @@ class bathtub extends uvm_report_object;
 	function void push_back_feature_file(string file);
 		feature_files.push_back(file);
 	endfunction : push_back_feature_file
+
+	function void set_report_object(uvm_report_object report_object);
+		this.report_object = report_object;
+	endfunction : set_report_object
 	
 	function uvm_report_object get_report_object();
 		return report_object;

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -119,9 +119,6 @@ classDiagram\
     namespace uvm_pkg{\
         class uvm_report_object\
     }\
-	namespace gherkin_pkg{\
-		class gherkin_doc_bundle\
-	}\
     bathtub --|> uvm_report_object\
     bathtub *-- test_sequence : current_test_seq\
 	test_sequence o-- bathtub : bt\

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -202,6 +202,13 @@ class bathtub extends uvm_report_object;
 		foreach (feature_files[i]) get_feature_files.push_back(feature_files[i]);
 	endfunction : get_feature_files
 
+	function void concat_feature_files(string files[$]);
+		feature_files = {feature_files, files};
+	endfunction : concat_feature_files
+
+	function void push_back_feature_file(string file);
+		feature_files.push_back(file);
+	endfunction : push_back_feature_file
 	
 	function uvm_report_object get_report_object();
 		return report_object;

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -426,6 +426,7 @@ The `get_dry_run()` function returns the dry-run status: 1=dry-run; 0=run. \
 Gets Bathtub's starting scenario number.\
 \
 The simulator command-line plusarg `+bathtub_start=<number>` sets the zero-based index of the scenario Bathtub will start running with.\
+This is useful for narrowing the simulation down to scenarios of interest, for example to reproduce failures quickly.\
 `get_starting_scenario_number()` returns the starting number.\
 	"*)
 	function int get_starting_scenario_number();
@@ -436,6 +437,7 @@ The simulator command-line plusarg `+bathtub_start=<number>` sets the zero-based
 Gets Bathtub's stopping scenario number.\
 \
 The simulator command-line plusarg `+bathtub_stop=<number>` sets the zero-based index of the scenario to stop running with.\
+This is useful for narrowing the simulation down to scenarios of interest, for example to reproduce failures quickly.\
 `get_stopping_scenario_number()` returns the stopping number.\
 	"*)
 	function int get_stopping_scenario_number();
@@ -467,10 +469,10 @@ Scenarios that have or inherit these tags will not run.\
 	endfunction : get_exclude_tags
 
 	(* doc$markdown = "\
-Concatenates steps to Bathtub's list of undefined steps.\
+Adds steps to Bathtub's list of undefined steps.\
 \
-Bathtub maintains a list of steps in the feature files which do not have matching step definitions.\
-The Gherkin runner uses `concat_undefined_steps()` to concatenate a queue of `gherkin_pkg::step` objects to the list.\
+As it runs, Bathtub maintains a list of feature file steps which do not have matching step definitions.\
+The Gherkin runner uses `concat_undefined_steps()` to add a queue of `gherkin_pkg::step` objects to the end of the list.\
 Bathtub uses the list to produce snippets at the end of `run_test()`.\
 This is for internal use.\
 	"*)

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -149,7 +149,7 @@ The `phase` argument is passed along from the phase method's parameter.\
 Be sure to call `configure()` prior to calling `run_test()`.\
 \
 Typical usage:\
-```\
+```sv\
 class bathtub_test extends uvm_test;\
     ...\
     task run_phase(uvm_phase phase);\
@@ -263,7 +263,7 @@ Concatenates strings to the end of the internal list of feature files to run.\
 Each string should be a single filename or a whitespace-separated list of filenames for Gherkin feature files.\
 \
 e.g.\
-```\
+```sv\
 bathtub.concat_feature_files('{\"path/to/features/feature_A.feature\"});\
 bathtub.concat_feature_files('{\"path/to/features/feature_B.feature\", \"path/to/features/feature_C.feature\"});\
 bathtub.concat_feature_files('{\"path/to/features/feature_D.feature path/to/features/feature_E.feature\"});\
@@ -280,7 +280,7 @@ Pushes a single string to the end of the internal list of feature files to run.\
 \
 `file` should be a single filename or a whitespace-separated list of filenames for Gherkin feature files.\
 e.g.\
-```\
+```sv\
 bathtub.push_back_feature_file(\"path/to/features/feature_A.feature\");\
 bathtub.push_back_feature_file(\"path/to/features/feature_B.feature path/to/features/feature_C.feature\");\
 bathtub.run_test(phase);\
@@ -296,7 +296,7 @@ Sets the Bathtub object's report object.\
 By default, Bathtub is its own UVM report object for the reports (`` `uvm_info()``, `` `uvm_error()``, etc.) it issues.\
 This accessor assigns a different report object.\
 e.g.\
-```\
+```sv\
 bathtub.set_report_object(uvm_root::get()); // Global object\
 bathtub.set_report_object(bathtub); // Back to self\
 ```\
@@ -306,56 +306,78 @@ bathtub.set_report_object(bathtub); // Back to self\
 	endfunction : set_report_object
 	
 	(* doc$markdown = "\
-docstring\
+Gets the Bathtub object's report object.\
+\
+By default, Bathtub is its own UVM report object for the reports (`` `uvm_info()``, `` `uvm_error()``, etc.) it issues, but the report object could be reassigned by `set_report_object()`.\
+Use `get_report_object()` to get the current report object.\
 	"*)
 	function uvm_report_object get_report_object();
 		return report_object;
 	endfunction : get_report_object
 
 	(* doc$markdown = "\
-docstring\
+Gets Bathtub's configured sequencer.\
+\
+Returns the sequencer on which Bathtub will execute all its sequences, as set by `configure()`.\
 	"*)
 	function uvm_sequencer_base get_sequencer();
 		return sequencer;
 	endfunction : get_sequencer
 	
 	(* doc$markdown = "\
-docstring\
+Gets Bathtub's configured sequence priority.\
+\
+Returns the sequence priority Bathtub starts all its sequences with, as set by `configure()`.\
 	"*)
 	function int get_sequence_priority();
 		return sequence_priority;
 	endfunction : get_sequence_priority
 	
 	(* doc$markdown = "\
-docstring\
+Gets Bathtub's configured `call_pre_post` value.\
+\
+Returns the `call_pre_post` value Bathtub starts all its sequences with, as set by `configure()`.\
 	"*)
 	function bit get_sequence_call_pre_post();
 		return sequence_call_pre_post;
 	endfunction : get_sequence_call_pre_post
 
 	(* doc$markdown = "\
-docstring\
+Gets Bathtub's dry-run status.\
+\
+If the simulation is run with the `+bathtub_dryrun` command-line plusarg, then Bathtub will parse the Gherkin feature files, but not run them.\
+The `get_dry_run()` function returns the dry-run status: 1=dry-run; 0=run. \
 	"*)
 	function bit get_dry_run();
 		return dry_run;
 	endfunction : get_dry_run
 
 	(* doc$markdown = "\
-docstring\
+Gets Bathtub's starting scenario number.\
+\
+The simulator command-line plusarg `+bathtub_start=<number>` sets the zero-based index of the scenario Bathtub will start running with.\
+`get_starting_scenario_number()` returns the starting number.\
 	"*)
 	function int get_starting_scenario_number();
 		return starting_scenario_number;
 	endfunction : get_starting_scenario_number
 
 	(* doc$markdown = "\
-docstring\
+Gets Bathtub's stopping scenario number.\
+\
+The simulator command-line plusarg `+bathtub_stop=<number>` sets the zero-based index of the scenario to stop running with.\
+`get_stopping_scenario_number()` returns the stopping number.\
 	"*)
 	function int get_stopping_scenario_number();
 		return stopping_scenario_number;
 	endfunction : get_stopping_scenario_number
 
 	(* doc$markdown = "\
-docstring\
+Gets the list of Bathtub's include tags.\
+\
+The simulator command-line plusarg `+bathtub_include=<tags>` sets the comma-separated list of Gherkin tags to include.\
+Only scenarios that have or inherit these tags will run.\
+`get_include_tags()` returns the list of tags.\
 	"*)
 	function strings_t get_include_tags();
 		get_include_tags = new("include_tags");
@@ -363,7 +385,11 @@ docstring\
 	endfunction : get_include_tags
 
 	(* doc$markdown = "\
-docstring\
+Gets the list of Bathtub's exclude tags.\
+\
+The simulator command-line plusarg `+bathtub_exclude=<tags>` sets the comma-separated list of Gherkin tags to exclude.\
+Scenarios that have or inherit these tags will not run.\
+`get_exclude_tags()` returns the list of tags.\
 	"*)
 	function strings_t get_exclude_tags();
 		get_exclude_tags = new("exclude_tags");
@@ -371,7 +397,11 @@ docstring\
 	endfunction : get_exclude_tags
 
 	(* doc$markdown = "\
-docstring\
+Concatenates steps to Bathtub's list of undefined steps.\
+\
+Bathtub maintains a list of steps in the feature files which do not have matching step definitions.\
+The Gherkin runner uses `concat_undefined_steps()` to concatenate a queue of `gherkin_pkg::step` objects to the list.\
+This is for internal use.\
 	"*)
 	function void concat_undefined_steps(gherkin_pkg::step steps[$]);
 		undefined_steps = {undefined_steps, steps};

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -84,7 +84,7 @@ endclass\
 Bathtub creates its own sequence, called `current_test_sequence`, which is an instance of class `bathtub_pkg::test_sequence`.\
 This sequence is the parent sequence of all sequences Bathtub creates, and provides context that persists for the duration of the simulation. \
 It contains UVM pools of various types so all the child sequences down to the step definitions can share information.\
-`current_test_sequence` also contains a reciprocal reference to the Bathtub object itself, so child sequences have access to it as well.\
+`current_test_sequence` also contains a reciprocal reference back to the Bathtub object, so child sequences have access to it as well.\
 \
 Bathtub extends class `uvm_report_object` and by default serves as its own report object for the messages its prints through `` `uvm_info()``, `` `uvm_error()``, etc.\
 The Bathtub object's verbosity can be set with simulator command line plusarg `+bathtub_verbosity=<verbosity>` independently of `+UVM_VERBOSITY=<verbosity>`.\

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -121,7 +121,7 @@ classDiagram\
     }\
     bathtub --|> uvm_report_object\
     bathtub *-- test_sequence : current_test_seq\
-	test_sequence o-- bathtub : bt\
+	test_sequence --> bathtub : bt\
 ```\
 	"*)
 class bathtub extends uvm_report_object;

--- a/src/bathtub_pkg/bathtub.svh
+++ b/src/bathtub_pkg/bathtub.svh
@@ -110,17 +110,19 @@ Initializes the Bathtub object with the given `name`.\
 	endfunction : new
 
 	(* doc$markdown = "\
-Configures the Bathtub object prior to running it.\
+Configures how the Bathtub object runs its sequences.\
 \
 Parameters `sequencer`, `parent_sequence`, `sequence_priority`, and `sequence_call_pre_post` are all related to the respective arguments of `uvm_sequence_base::start()`.\
-These parameters all influence how Bathtub executes its sequences.\
+These parameters all influence how Bathtub executes its context and step definition sequences.\
+Call this function before calling `run_test()`.\
 \
-`sequencer` is the sequencer on which Bathtub will execute all its context and step definition sequences.\
+`sequencer` is the sequencer on which Bathtub will execute all its sequences.\
+This is the only required argument.\
 \
 The Bathtub object creates its own context sequence called `current_test_seq`.\
 If `parent_sequence` is null, then `current_test_seq` is a root parent, otherwise it is a child of `parent_sequence`.\
 \
-Bathtub assigns `sequence_priority` to all its context and step definition sequences.\
+Bathtub assigns `sequence_priority` to all its sequences.\
 \
 `sequence_call_pre_post` determines whether the sequences' `pre_body()` and `post_body()` tasks are called.\
 	"*)
@@ -137,6 +139,31 @@ Bathtub assigns `sequence_priority` to all its context and step definition seque
 	endfunction : configure
 
 
+	(* doc$markdown = "\
+Run the Bathtub test.\
+\
+`run_test()` causes the Bathtub object to read the provided feature files and execute them on the configured sequencer.\
+\
+This task is typically called from a UVM test or component's phase implementation method, such as `run_phase()`.\
+The `phase` argument is passed along from the phase method's parameter.\
+Be sure to call `configure()` prior to calling `run_test()`.\
+\
+Typical usage:\
+```\
+class bathtub_test extends uvm_test;\
+    ...\
+    task run_phase(uvm_phase phase);\
+        phase.raise_objection(this);\
+        bathtub.configure(my_env.my_sequencer);\
+        bathtub.run_test(phase);\
+        phase.drop_objection(this);\
+    endtask\
+endclass\
+```\
+If Bathtub encounters any feature file steps that don't have step definitions registered in the resource database,\
+then before returning, `run_test()` outputs a step definition snippet for each of the steps in the log file and in a separate file called `bathtub_snippets.svh`.\
+The snippets can be used as the basis for actual step definitions.\
+	"*)
 	virtual task run_test(uvm_phase phase);
 
 		// Process plusarg overrides

--- a/src/bathtub_pkg/bathtub_pkg.svh
+++ b/src/bathtub_pkg/bathtub_pkg.svh
@@ -25,7 +25,10 @@ SOFTWARE.
 `ifndef __BATHTUB_PKG_SVH
 `define __BATHTUB_PKG_SVH
 
+import uvm_pkg::*;
+
 typedef enum {Given, When, Then, And, But, \* } step_keyword_t;
+typedef uvm_queue#(string) strings_t;
 
 parameter byte CR = 13; // ASCII carriage return
 parameter string STEP_DEF_RESOURCE_NAME = "bathtub_pkg::step_definition_interface";

--- a/src/bathtub_pkg/test_sequence.svh
+++ b/src/bathtub_pkg/test_sequence.svh
@@ -66,29 +66,41 @@ class test_sequence extends context_sequence implements test_sequence_interface;
 		gherkin_parser parser;
 		gherkin_document_printer printer;
 		gherkin_document_runner runner;
+		strings_t feature_files;
+		strings_t include_tags;
+		strings_t exclude_tags;
+		string include_tags_q[$];
+		string exclude_tags_q[$];
 
-		foreach (bt.feature_files[i]) begin : iterate_over_feature_files
+		include_tags = bt.get_include_tags();
+		for (int i = 0; i < include_tags.size(); i++) include_tags_q.push_back(include_tags.get(i));
+		exclude_tags = bt.get_exclude_tags();
+		for (int i = 0; i < exclude_tags.size(); i++) exclude_tags_q.push_back(exclude_tags.get(i));
+		feature_files = bt.get_feature_files();
+		for (int i = 0; i < feature_files.size(); i++) begin : iterate_over_feature_files
 			gherkin_pkg::step undefined_steps[$];
 			
-			`uvm_info_context(`BATHTUB__GET_SCOPE_NAME(-2), {"Feature file: ", bt.feature_files[i]}, UVM_HIGH, bt.report_object)
+			`uvm_info_context(`BATHTUB__GET_SCOPE_NAME(-2), {"Feature file: ", feature_files.get(i)}, UVM_HIGH, bt.get_report_object())
 
-			parser = gherkin_parser::type_id::create("parser").configure(bt.report_object);
+			parser = gherkin_parser::type_id::create("parser").configure(bt.get_report_object());
 
-			parser.parse_feature_file(bt.feature_files[i], gherkin_doc_bundle);
+			parser.parse_feature_file(feature_files.get(i), gherkin_doc_bundle);
 
 			assert_gherkin_doc_is_not_null : assert (gherkin_doc_bundle.document);
 
-			if (bt.report_object.get_report_verbosity_level() >= UVM_HIGH) begin
+			if (bt.get_report_object().get_report_verbosity_level() >= UVM_HIGH) begin
 				printer = gherkin_document_printer::create_new("printer", gherkin_doc_bundle.document);
 				printer.print();
 			end
 
 			runner = gherkin_document_runner::create_new("runner", gherkin_doc_bundle.document);
-			runner.configure(bt.sequencer, this, bt.sequence_priority, bt.sequence_call_pre_post, phase, bt.dry_run, bt.starting_scenario_number, bt.stopping_scenario_number, bt.include_tags, bt.exclude_tags, bt.report_object);
+			runner.configure(bt.get_sequencer(), this, bt.get_sequence_priority(), bt.get_sequence_call_pre_post(),
+				phase, bt.get_dry_run(), bt.get_starting_scenario_number(), bt.get_stopping_scenario_number(),
+				include_tags_q, exclude_tags_q, bt.get_report_object());
 			runner.run();
 
 			runner.get_undefined_steps(undefined_steps);
-			bt.undefined_steps = {bt.undefined_steps, undefined_steps};
+			bt.concat_undefined_steps(undefined_steps);
 			
 `ifdef BATHTUB_VERBOSITY_TEST
 			parser.test_verbosity();


### PR DESCRIPTION
Created a means to embed doc strings in the source code, `bathtub.svh`, and use them to automatically generate a reference page.

Living documentation.

<https://github.com/williaml33moore/bathtub/wiki/bathtub-Class-Reference>

Closes issue #101.